### PR TITLE
Neutralize virtual gamepads for Windows touch keyboard

### DIFF
--- a/PadForge.App/Common/Input/HMaestroVirtualController.cs
+++ b/PadForge.App/Common/Input/HMaestroVirtualController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using HIDMaestro;
 using PadForge.Engine;
 using PadForge.Services;
@@ -27,6 +28,8 @@ namespace PadForge.Common.Input
         private DualSensePassthroughDispatcher _ds5Dispatcher;
         private UserEffectsDispatcher _userEffectsDispatcher;
         private bool _disposed;
+        private static readonly PropertyInfo NeutralizedProperty =
+            typeof(HMController).GetProperty("Neutralized", BindingFlags.Instance | BindingFlags.Public);
 
         // DualSense / DualSense Edge VID/PID — used to gate the
         // DS5 effect message pass-through dispatcher.  Both USB and BT
@@ -46,6 +49,32 @@ namespace PadForge.Common.Input
         public string ProfileId => _profile.Id;
         public ushort ProfileVendorId => _profile.VendorId;
         public ushort ProfileProductId => _profile.ProductId;
+
+        private bool _neutralized;
+
+        /// <summary>
+        /// Test/diagnostic neutral-output switch. When enabled, the underlying
+        /// HIDMaestro controller stays connected but publishes neutral input
+        /// frames regardless of PadForge's mapped output.
+        /// </summary>
+        public bool Neutralized
+        {
+            get => _neutralized;
+            set
+            {
+                _neutralized = value;
+                ApplyNeutralizedToController();
+            }
+        }
+
+        private void ApplyNeutralizedToController()
+        {
+            if (_controller == null || NeutralizedProperty == null)
+                return;
+
+            try { NeutralizedProperty.SetValue(_controller, _neutralized); }
+            catch { /* Older or incompatible HIDMaestro builds simply ignore this optional feature. */ }
+        }
 
         // Cached HMAxis keys for the active profile's first two sticks +
         // first two triggers, resolved once at construction so the 1 kHz
@@ -151,6 +180,7 @@ namespace PadForge.Common.Input
         {
             if (IsConnected) return;
             _controller = _ctx.CreateController(_profile);
+            ApplyNeutralizedToController();
 
             // Publish PID Pool + initial PID State BEFORE any GetFeature can
             // race in. DirectInput's CDIEffect::CreateEffect issues

--- a/PadForge.App/Common/Input/InputManager.Step5.VirtualDevices.cs
+++ b/PadForge.App/Common/Input/InputManager.Step5.VirtualDevices.cs
@@ -128,6 +128,34 @@ namespace PadForge.Common.Input
         /// Null entries are slots without an active VC.</summary>
         public IVirtualController[] GetVirtualControllers() => _virtualControllers;
 
+        private volatile bool _neutralizeHMaestroOutputs;
+
+        /// <summary>
+        /// Diagnostic global neutral switch for every HIDMaestro-backed virtual
+        /// controller. Does not destroy or reconnect devices; it forwards to
+        /// HMController.Neutralized on each live HM VC and is applied to newly
+        /// created HM VCs before they receive mapped output.
+        /// </summary>
+        public bool NeutralizeHMaestroOutputs
+        {
+            get => _neutralizeHMaestroOutputs;
+            set
+            {
+                _neutralizeHMaestroOutputs = value;
+                ApplyNeutralizeHMaestroOutputs(value);
+            }
+        }
+
+        private void ApplyNeutralizeHMaestroOutputs(bool value)
+        {
+            foreach (var vc in _virtualControllers)
+            {
+                if (vc is not HMaestroVirtualController hm) continue;
+                try { hm.Neutralized = value; }
+                catch { /* best-effort: live diagnostic toggle must not stop polling */ }
+            }
+        }
+
         /// <summary>
         /// Configured virtual controller category per slot (Xbox / PlayStation /
         /// Extended / MIDI / KBM). The UI writes this via InputService at 30Hz;
@@ -1375,6 +1403,8 @@ namespace PadForge.Common.Input
                 // / live-edit hooks alongside MidiConfig / ExtendedConfig.
                 if (vc is HMaestroVirtualController hmVc)
                 {
+                    hmVc.Neutralized = _neutralizeHMaestroOutputs;
+
                     var psCfg = _playStationConfigs[padIndex];
                     if (psCfg != null)
                         hmVc.AttachPlayStationConfig(psCfg);

--- a/PadForge.App/MainWindow.xaml.cs
+++ b/PadForge.App/MainWindow.xaml.cs
@@ -431,6 +431,7 @@ namespace PadForge
                      or nameof(SettingsViewModel.EnablePollingOnFocusLoss)
                      or nameof(SettingsViewModel.PollingRateMs)
                      or nameof(SettingsViewModel.HmInactivityDestroyTimeoutSeconds)
+                     or nameof(SettingsViewModel.NeutralizeHidMaestroOnTouchKeyboardFocus)
                      or nameof(SettingsViewModel.EnableInputHiding)
                      or nameof(SettingsViewModel.KeepHidHideCloaksBetweenLaunches)
                      or nameof(SettingsViewModel.Use2DControllerView)

--- a/PadForge.App/Resources/Strings/Strings.Designer.cs
+++ b/PadForge.App/Resources/Strings/Strings.Designer.cs
@@ -299,6 +299,9 @@ public class Strings : INotifyPropertyChanged
     public string Settings_AddDots => Get("Settings_AddDots");
     public string Settings_HIDMaestro => Get("Settings_HIDMaestro");
     public string Settings_HIDMaestroDesc => Get("Settings_HIDMaestroDesc");
+    public string Settings_NeutralizeHidMaestroOnTouchKeyboardFocus => Get("Settings_NeutralizeHidMaestroOnTouchKeyboardFocus");
+    public string Settings_NeutralizeHidMaestroOnTouchKeyboardFocusTooltip => Get("Settings_NeutralizeHidMaestroOnTouchKeyboardFocusTooltip");
+    public string Settings_NeutralizeHidMaestroOnTouchKeyboardFocusDesc => Get("Settings_NeutralizeHidMaestroOnTouchKeyboardFocusDesc");
     public string Settings_MidiServices => Get("Settings_MidiServices");
     public string Settings_MidiDesc => Get("Settings_MidiDesc");
     public string Settings_MidiOsRequired => Get("Settings_MidiOsRequired");

--- a/PadForge.App/Resources/Strings/Strings.pt-BR.resx
+++ b/PadForge.App/Resources/Strings/Strings.pt-BR.resx
@@ -257,6 +257,9 @@
   <data name="Settings_AddDots" xml:space="preserve"><value>Adicionar...</value></data>
   <data name="Settings_HIDMaestro" xml:space="preserve"><value>Driver HIDMaestro</value></data>
   <data name="Settings_HIDMaestroDesc" xml:space="preserve"><value>Motor de controle HID virtual em modo usuário. Integrado ao PadForge.App. Instalado automaticamente na primeira criação de um controle virtual. Substitui ViGEmBus e vJoy na v3.</value></data>
+  <data name="Settings_NeutralizeHidMaestroOnTouchKeyboardFocus" xml:space="preserve"><value>Deixar gamepads virtuais em modo neutro ao detectar o teclado virtual do Windows</value></data>
+  <data name="Settings_NeutralizeHidMaestroOnTouchKeyboardFocusTooltip" xml:space="preserve"><value>Mantém os controles virtuais HIDMaestro conectados, mas envia input neutro enquanto o teclado virtual do Windows está visível.</value></data>
+  <data name="Settings_NeutralizeHidMaestroOnTouchKeyboardFocusDesc" xml:space="preserve"><value>Usa um helper sem janela via COM para detectar o teclado virtual do Windows e impedir que inputs do gamepad cheguem aos jogos enquanto você digita.</value></data>
   <data name="Settings_MidiServices" xml:space="preserve"><value>Windows MIDI Services</value></data>
   <data name="Settings_MidiDesc" xml:space="preserve"><value>Runtime SDK para saída de dispositivo MIDI virtual. Baixado do GitHub (~210 MB).</value></data>
   <data name="Settings_MidiOsRequired" xml:space="preserve"><value>Requer Windows 11 24H2 (build 26100) ou posterior</value></data>

--- a/PadForge.App/Resources/Strings/Strings.resx
+++ b/PadForge.App/Resources/Strings/Strings.resx
@@ -261,6 +261,9 @@
   <data name="Settings_AddDots" xml:space="preserve"><value>Add...</value></data>
   <data name="Settings_HIDMaestro" xml:space="preserve"><value>HIDMaestro Driver</value></data>
   <data name="Settings_HIDMaestroDesc" xml:space="preserve"><value>User-mode virtual HID controller engine. Embedded in PadForge.App. Installed automatically on first virtual controller creation. Replaces ViGEmBus and vJoy in v3.</value></data>
+  <data name="Settings_NeutralizeHidMaestroOnTouchKeyboardFocus" xml:space="preserve"><value>Neutralize virtual gamepads when the Windows touch keyboard is detected</value></data>
+  <data name="Settings_NeutralizeHidMaestroOnTouchKeyboardFocusTooltip" xml:space="preserve"><value>Keeps HIDMaestro virtual controllers connected, but sends neutral input while the Windows touch keyboard is visible.</value></data>
+  <data name="Settings_NeutralizeHidMaestroOnTouchKeyboardFocusDesc" xml:space="preserve"><value>Uses a headless COM helper to detect the Windows touch keyboard and prevent gamepad input from reaching games while you type.</value></data>
   <data name="Settings_MidiServices" xml:space="preserve"><value>Windows MIDI Services</value></data>
   <data name="Settings_MidiDesc" xml:space="preserve"><value>SDK runtime for virtual MIDI device output. Downloaded from GitHub (~210 MB).</value></data>
   <data name="Settings_MidiOsRequired" xml:space="preserve"><value>Requires Windows 11 24H2 (build 26100) or later</value></data>

--- a/PadForge.App/Services/InputService.cs
+++ b/PadForge.App/Services/InputService.cs
@@ -51,6 +51,8 @@ namespace PadForge.Services
         private Vibration _constantTriggerForceScratchSony;
         private DispatcherTimer _uiTimer;
         private ForegroundMonitorService _foregroundMonitor;
+        private WindowsTouchKeyboardFocusMonitor _touchKeyboardFocusMonitor;
+        private bool _touchKeyboardNeutralActive;
         private ProfileData _defaultProfileSnapshot;
 
         // Active profile's touchpad custom-gesture working list. Mirrors
@@ -252,6 +254,7 @@ namespace PadForge.Services
             _inputManager = new InputManager();
             _inputManager.PollingIntervalMs = _mainVm.Settings.PollingRateMs;
             _inputManager.HmInactivityTimeoutSeconds = _mainVm.Settings.HmInactivityDestroyTimeoutSeconds;
+            _inputManager.NeutralizeHMaestroOutputs = false;
 
             // Copy controller types and per-slot configs immediately so Step 5
             // creates the correct VC types from the first polling cycle.
@@ -909,6 +912,7 @@ namespace PadForge.Services
 
             // Enter idle immediately if no slots are created.
             UpdateIdleState();
+            ConfigureTouchKeyboardNeutralization();
         }
 
         /// <summary>
@@ -984,6 +988,7 @@ namespace PadForge.Services
                 _foregroundMonitor.ProfileSwitchRequired -= OnProfileSwitchRequired;
                 _foregroundMonitor = null;
             }
+            StopTouchKeyboardFocusMonitor();
             StopDsuServer();
             StopWebServer();
             StopAudioBassDetector();
@@ -4223,6 +4228,10 @@ namespace PadForge.Services
             {
                 _inputManager.HmInactivityTimeoutSeconds = _mainVm.Settings.HmInactivityDestroyTimeoutSeconds;
             }
+            else if (e.PropertyName == nameof(SettingsViewModel.NeutralizeHidMaestroOnTouchKeyboardFocus))
+            {
+                ConfigureTouchKeyboardNeutralization();
+            }
             else if (e.PropertyName == nameof(SettingsViewModel.EnableInputHiding))
             {
                 if (_mainVm.Settings.EnableInputHiding)
@@ -4230,6 +4239,60 @@ namespace PadForge.Services
                 else
                     RemoveDeviceHiding();
             }
+        }
+
+        private void ConfigureTouchKeyboardNeutralization()
+        {
+            if (_mainVm.Settings.NeutralizeHidMaestroOnTouchKeyboardFocus)
+            {
+                if (_touchKeyboardFocusMonitor == null)
+                {
+                    _touchKeyboardFocusMonitor = new WindowsTouchKeyboardFocusMonitor();
+                    _touchKeyboardFocusMonitor.VisibilityChanged += OnTouchKeyboardVisibilityChanged;
+                    _touchKeyboardFocusMonitor.Start();
+                }
+            }
+            else
+            {
+                StopTouchKeyboardFocusMonitor();
+            }
+        }
+
+        private void OnTouchKeyboardVisibilityChanged(bool visible)
+        {
+            if (_dispatcher.CheckAccess())
+            {
+                SetTouchKeyboardNeutralActive(visible);
+            }
+            else
+            {
+                _dispatcher.BeginInvoke(new Action(() => SetTouchKeyboardNeutralActive(visible)));
+            }
+        }
+
+        private void SetTouchKeyboardNeutralActive(bool active)
+        {
+            if (active && !_mainVm.Settings.NeutralizeHidMaestroOnTouchKeyboardFocus)
+                return;
+
+            if (_touchKeyboardNeutralActive == active)
+                return;
+
+            _touchKeyboardNeutralActive = active;
+            if (_inputManager != null)
+                _inputManager.NeutralizeHMaestroOutputs = active;
+        }
+
+        private void StopTouchKeyboardFocusMonitor()
+        {
+            if (_touchKeyboardFocusMonitor != null)
+            {
+                _touchKeyboardFocusMonitor.VisibilityChanged -= OnTouchKeyboardVisibilityChanged;
+                _touchKeyboardFocusMonitor.Dispose();
+                _touchKeyboardFocusMonitor = null;
+            }
+
+            SetTouchKeyboardNeutralActive(false);
         }
 
         private void OnDashboardPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/PadForge.App/Services/SettingsService.cs
+++ b/PadForge.App/Services/SettingsService.cs
@@ -948,6 +948,9 @@ namespace PadForge.Services
             vm.EnablePollingOnFocusLoss = appSettings.EnablePollingOnFocusLoss;
             vm.PollingRateMs = appSettings.PollingRateMs;
             vm.HmInactivityDestroyTimeoutSeconds = appSettings.HmInactivityDestroyTimeoutSeconds;
+            vm.NeutralizeHidMaestroOnTouchKeyboardFocus =
+                appSettings.NeutralizeHidMaestroOnTouchKeyboardFocus
+                || appSettings.TestNeutralHidMaestroOutputs;
             vm.SelectedThemeIndex = appSettings.ThemeIndex;
             vm.EnableInputHiding = appSettings.EnableInputHiding;
             vm.KeepHidHideCloaksBetweenLaunches = appSettings.KeepHidHideCloaksBetweenLaunches;
@@ -2483,6 +2486,8 @@ namespace PadForge.Services
                 EnablePollingOnFocusLoss = vm.EnablePollingOnFocusLoss,
                 PollingRateMs = vm.PollingRateMs,
                 HmInactivityDestroyTimeoutSeconds = vm.HmInactivityDestroyTimeoutSeconds,
+                NeutralizeHidMaestroOnTouchKeyboardFocus = vm.NeutralizeHidMaestroOnTouchKeyboardFocus,
+                TestNeutralHidMaestroOutputs = false,
                 ThemeIndex = vm.SelectedThemeIndex,
                 Language = vm.LanguageCode,
                 EnableAutoProfileSwitching = vm.EnableAutoProfileSwitching,
@@ -3043,6 +3048,7 @@ namespace PadForge.Services
             settingsVm.EnablePollingOnFocusLoss = true;
             settingsVm.PollingRateMs = 1;
             settingsVm.HmInactivityDestroyTimeoutSeconds = 60;
+            settingsVm.NeutralizeHidMaestroOnTouchKeyboardFocus = false;
             settingsVm.SelectedThemeIndex = 0;
             settingsVm.EnableInputHiding = true;
             settingsVm.EnableAutoProfileSwitching = false;
@@ -3440,6 +3446,12 @@ namespace PadForge.Services
         /// </summary>
         [XmlElement]
         public int HmInactivityDestroyTimeoutSeconds { get; set; } = 60;
+
+        [XmlElement]
+        public bool NeutralizeHidMaestroOnTouchKeyboardFocus { get; set; }
+
+        [XmlElement]
+        public bool TestNeutralHidMaestroOutputs { get; set; }
 
         [XmlElement]
         public int ThemeIndex { get; set; }

--- a/PadForge.App/Services/WindowsTouchKeyboardFocusMonitor.cs
+++ b/PadForge.App/Services/WindowsTouchKeyboardFocusMonitor.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace PadForge.Services
+{
+    /// <summary>
+    /// Headless helper that polls the Windows Input Pane COM API and reports
+    /// when the cloaked touch keyboard is visible.
+    /// </summary>
+    internal sealed class WindowsTouchKeyboardFocusMonitor : IDisposable
+    {
+        private const int S_OK = 0;
+
+        private readonly TimeSpan _pollInterval;
+        private Thread _thread;
+        private CancellationTokenSource _cts;
+        private bool _disposed;
+
+        public WindowsTouchKeyboardFocusMonitor(TimeSpan? pollInterval = null)
+        {
+            _pollInterval = pollInterval ?? TimeSpan.FromMilliseconds(150);
+        }
+
+        public event Action<bool> VisibilityChanged;
+
+        public void Start()
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(WindowsTouchKeyboardFocusMonitor));
+            if (_thread != null) return;
+
+            _cts = new CancellationTokenSource();
+            _thread = new Thread(() => PollLoop(_cts.Token))
+            {
+                IsBackground = true,
+                Name = "WindowsTouchKeyboardFocusMonitor",
+            };
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+        }
+
+        public void Stop()
+        {
+            var cts = _cts;
+            var thread = _thread;
+            _cts = null;
+            _thread = null;
+
+            if (cts != null)
+            {
+                try { cts.Cancel(); } catch { }
+            }
+
+            if (thread != null && thread.IsAlive)
+            {
+                try { thread.Join(1000); } catch { }
+            }
+
+            cts?.Dispose();
+        }
+
+        private void PollLoop(CancellationToken token)
+        {
+            IFrameworkInputPane inputPane = null;
+            bool? previous = null;
+            try
+            {
+                inputPane = (IFrameworkInputPane)(object)new FrameworkInputPane();
+
+                while (!token.IsCancellationRequested)
+                {
+                    bool visible = IsTouchKeyboardVisible(inputPane);
+                    if (previous != visible)
+                    {
+                        previous = visible;
+                        try { VisibilityChanged?.Invoke(visible); } catch { }
+                    }
+
+                    try
+                    {
+                        if (token.WaitHandle.WaitOne(_pollInterval)) break;
+                    }
+                    catch
+                    {
+                        break;
+                    }
+                }
+            }
+            catch
+            {
+                if (previous != false)
+                {
+                    try { VisibilityChanged?.Invoke(false); } catch { }
+                }
+            }
+            finally
+            {
+                if (inputPane != null && Marshal.IsComObject(inputPane))
+                    Marshal.ReleaseComObject(inputPane);
+            }
+        }
+
+        private static bool IsTouchKeyboardVisible(IFrameworkInputPane inputPane)
+        {
+            if (inputPane == null) return false;
+
+            try
+            {
+                int hr = inputPane.Location(out var rect);
+                return hr == S_OK && !rect.IsEmpty;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        [ComImport]
+        [Guid("D5120AA3-46BA-44C5-822D-CA8092C1FC72")]
+        private sealed class FrameworkInputPane
+        {
+        }
+
+        [ComImport]
+        [Guid("5752238B-24F0-495A-82F1-2FD593056796")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IFrameworkInputPane
+        {
+            [PreserveSig]
+            int Advise(
+                [MarshalAs(UnmanagedType.IUnknown)] object pWindow,
+                [MarshalAs(UnmanagedType.IUnknown)] object pHandler,
+                out uint pdwCookie);
+
+            [PreserveSig]
+            int AdviseWithHWND(
+                nint hwnd,
+                [MarshalAs(UnmanagedType.IUnknown)] object pHandler,
+                out uint pdwCookie);
+
+            [PreserveSig]
+            int Unadvise(uint dwCookie);
+
+            [PreserveSig]
+            int Location(out Rect prcInputPaneScreenLocation);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Rect
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+
+            public bool IsEmpty => Left == 0 && Top == 0 && Right == 0 && Bottom == 0;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            Stop();
+        }
+    }
+}

--- a/PadForge.App/ViewModels/SettingsViewModel.cs
+++ b/PadForge.App/ViewModels/SettingsViewModel.cs
@@ -409,6 +409,18 @@ namespace PadForge.ViewModels
             set => SetProperty(ref _hmInactivityDestroyTimeoutSeconds, Math.Clamp(value, 0, 3600));
         }
 
+        private bool _neutralizeHidMaestroOnTouchKeyboardFocus;
+
+        /// <summary>
+        /// When enabled, HIDMaestro-backed virtual controllers stay connected
+        /// but publish neutral inputs while Windows' touch keyboard has focus.
+        /// </summary>
+        public bool NeutralizeHidMaestroOnTouchKeyboardFocus
+        {
+            get => _neutralizeHidMaestroOnTouchKeyboardFocus;
+            set => SetProperty(ref _neutralizeHidMaestroOnTouchKeyboardFocus, value);
+        }
+
         private bool _enableInputHiding = true;
 
         /// <summary>

--- a/PadForge.App/Views/SettingsPage.xaml
+++ b/PadForge.App/Views/SettingsPage.xaml
@@ -205,6 +205,13 @@
                         <TextBlock Text="{Binding HIDMaestroVersion}" FontSize="12"
                                    Opacity="0.6" Margin="0,4,0,0"/>
                     </StackPanel>
+                    <CheckBox Content="{Binding Settings_NeutralizeHidMaestroOnTouchKeyboardFocus, Source={x:Static strings:Strings.Instance}}"
+                              IsChecked="{Binding NeutralizeHidMaestroOnTouchKeyboardFocus}"
+                              ToolTip="{Binding Settings_NeutralizeHidMaestroOnTouchKeyboardFocusTooltip, Source={x:Static strings:Strings.Instance}}"
+                              Margin="0,12,0,0"/>
+                    <TextBlock Text="{Binding Settings_NeutralizeHidMaestroOnTouchKeyboardFocusDesc, Source={x:Static strings:Strings.Instance}}"
+                               Style="{StaticResource CardDescription}" Margin="24,4,0,0"
+                               TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
## Summary
- Replaces the manual HIDMaestro neutral test toggle with a localized setting that neutralizes virtual gamepads while the Windows touch keyboard is visible.
- Adds a headless COM Input Pane monitor using `IFrameworkInputPane.Location()` to detect the cloaked touch keyboard without stealing game focus.
- Wires the detected visibility state through PadForge's HIDMaestro virtual controller pipeline without embedding updated HIDMaestro binaries.

## Test plan
- Verified the COM probe detected touch keyboard visible/hidden transitions locally.
- Compiled `PadForge.App` to a separate output directory in Release with 0 warnings and 0 errors.

Made with [Cursor](https://cursor.com)